### PR TITLE
Bump django-aullauth from 0.40.0 to 0.43.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ django==2.2.26
 pytz==2018.4
 pillow==8.4
 django-recaptcha==2.0.6
-django-allauth==0.40.0
+django-allauth==0.43.0


### PR DESCRIPTION
closes #121